### PR TITLE
Fix gitignore for env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-# .env*.local
+*.env
+*.env.*
 *token.json*
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- ignore `.env` and `.env.*` files
- add trailing newline to `.gitignore`

## Testing
- `pytest -q` *(fails: ProxyError during HTTP requests)*

------
https://chatgpt.com/codex/tasks/task_e_68496425ded48322bd1bb8a4c338bf74